### PR TITLE
add optional s3_event_notification_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ No modules.
 | <a name="input_name_update"></a> [name\_update](#input\_name\_update) | Name for resources associated with anti-virus updating | `string` | `"s3-anti-virus-updates"` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | ARN of the boundary policy to attach to IAM roles. | `string` | `null` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | Instruction set architecture for your Lambda function. Valid values are 'x86\_64' and 'arm64' | `string` | `"arm64"` | no |
+| <a name="input_s3_event_notification_name"></a> [s3\_event\_notification\_name](#input\_s3\_event\_notification\_name) | s3 event notification name | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | <a name="input_timeout_seconds"></a> [timeout\_seconds](#input\_timeout\_seconds) | Lambda timeout, in seconds | `string` | `300` | no |
 

--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -139,7 +139,7 @@ resource "aws_s3_bucket_notification" "main_scan" {
   bucket = element(data.aws_s3_bucket.main_scan.*.id, count.index)
 
   lambda_function {
-    id                  = element(data.aws_s3_bucket.main_scan.*.id, count.index)
+    id                  = var.s3_event_notification_name ? var.s3_event_notification_name : element(data.aws_s3_bucket.main_scan.*.id, count.index)
     lambda_function_arn = aws_lambda_function.main_scan.arn
     events              = ["s3:ObjectCreated:*"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -136,3 +136,9 @@ variable "activate_s3_event_notification" {
   type        = bool
   default     = false
 }
+
+variable "s3_event_notification_name" {
+  description = "s3 event notification name"
+  type        = string
+  default     = null
+}

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
 # Incrementing the version number below will trigger a
 # release tag with that version to be created automatically.
-3.0.0
+3.0.1


### PR DESCRIPTION
extend the module and allow to pass the name of the s3 event notification to allow terraform import of existing notifications