### PR TITLE
fix s3_event_notification_name condition

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -139,7 +139,7 @@ resource "aws_s3_bucket_notification" "main_scan" {
   bucket = element(data.aws_s3_bucket.main_scan.*.id, count.index)
 
   lambda_function {
-    id                  = var.s3_event_notification_name ? var.s3_event_notification_name : element(data.aws_s3_bucket.main_scan.*.id, count.index)
+    id                  = var.s3_event_notification_name == null ? element(data.aws_s3_bucket.main_scan.*.id, count.index) : var.s3_event_notification_name
     lambda_function_arn = aws_lambda_function.main_scan.arn
     events              = ["s3:ObjectCreated:*"]
   }

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
 # Incrementing the version number below will trigger a
 # release tag with that version to be created automatically.
-3.0.1
+3.0.2


### PR DESCRIPTION
oopps 😬 i didn't handle TF conditional correctly. keep using ruby-way when checking `null` but gotta do more typing in terraform 😆 

it will fix this error:
https://app.terraform.io/app/onemedical/workspaces/file-snoop-lambda-main/runs/run-oHcdLrxNYXBMe7BD