### PR TITLE
INFRA-5855 add missing kms:Decrypt permission to lambda role

### DIFF
--- a/anti-virus-scan.tf
+++ b/anti-virus-scan.tf
@@ -88,6 +88,7 @@ data "aws_iam_policy_document" "main_scan" {
 
       actions = [
         "kms:GenerateDataKey",
+        "kms:Decrypt"
       ]
 
       resources = [

--- a/version
+++ b/version
@@ -1,3 +1,3 @@
 # Incrementing the version number below will trigger a
 # release tag with that version to be created automatically.
-3.0.2
+3.0.3


### PR DESCRIPTION
[INFRA-5855](https://onemedical.atlassian.net/browse/INFRA-5855)

- Bump version to v3.0.3
- Add `kms:Decrypt` to role permissions

[INFRA-5855]: https://onemedical.atlassian.net/browse/INFRA-5855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ